### PR TITLE
🐞 fix: Add space to fix dependancy name parsing

### DIFF
--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -27,7 +27,7 @@ function getRawVersion(title: string, target: "from" | "to"): string {
   const regex =
     /(?<version>(?<major>0|[1-9]\d*)(\.(?<minor>(0|[1-9]\d*))(\.(?<patch>(0|[1-9]\d*))(?:-((?<remainder>0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)?)?)/;
 
-  const matches = title.match(new RegExp(`${target} \\D*${regex.source}`));
+  const matches = title.match(new RegExp(` ${target} \\D*${regex.source}`));
 
   if (matches && matches.groups && matches.groups.version && matches.groups.major) {
     if (matches.groups.remainder) {

--- a/tests/parse.spec.ts
+++ b/tests/parse.spec.ts
@@ -43,6 +43,21 @@ describe("parse", () => {
       expect(to).toBe(target);
     });
 
+    test("Returns the right versions from title event with deps name containing 'to'", () => {
+      expect.assertions(4);
+
+      const source = "0.0.1";
+      const target = "0.0.2";
+      const from = getRawVersion(`Bump deps-name-to from ${source} to ${target}`, "from");
+      const to = getRawVersion(`Bump deps-name-to from ${source} to ${target}`, "to");
+
+      expect(typeof from).toBe("string");
+      expect(from).toBe(source);
+
+      expect(typeof to).toBe("string");
+      expect(to).toBe(target);
+    });
+
     test("Rounds incomplete numeric versions to semver", () => {
       expect.assertions(4);
 


### PR DESCRIPTION
## Description

We've been ping for review where we shouldn't have been. The bump here is `@opentelemetry/exporter-trace-otlp-proto from 0.33.0 to 0.34.0` with `@remix-run/*:minor` as `npm-disallowlist`.

After investigation I found the reason, the dependancy name ends with `to`, therefore, when parsing the PR's title to get the `to` version, it takes `to from 0.33.0` and extracts the digits of the `from` again.

The fix is simple: I added a space before the target: ` to` instead of `to`.

## Related Issue

https://linear.app/fewlines/issue/TRB-171/fix-auto-merge

## Motivation and Context

We don't want 🐞🐛🐝 of any kind (at least here)

## How Has This Been Tested?

I added a test case.

## Types of changes

- ~Chore (non-breaking change which refactors / improves the existing code base)~
- Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to
  change)~

## Checklist:

- 🔴 My change requires a change to the documentation.
- 🔴 I have updated the documentation accordingly.
- ✅ I have added tests to cover my changes.
- ✅ All new and existing tests passed.
- ✅ I have read the [CONTRIBUTING](https://github.com/fewlinesco/eslint-config/blob/main/CONTRIBUTING.md) document.
